### PR TITLE
Replace libc_alloc with custom allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 vex-rt-macros = { version="0.1", path = "macros" }
 libc = { version = "0.2", default-features = false }
-libc_alloc = "1.0.2"
 libc-print = "0.1.14"
 spin = "0.7.0"
 

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,8 +1,10 @@
 #![no_std]
 #![no_main]
 
+extern crate alloc;
 extern crate vex_rt;
 
+use alloc::string::*;
 use libc_print::std_name::println;
 
 struct Robot;
@@ -10,6 +12,8 @@ struct Robot;
 #[vex_rt::entry]
 impl Robot {
     fn initialize() -> Self {
+        let s = "Hello, world".to_string();
+        println!("{}", s);
         Robot
     }
     fn autonomous(&self) {

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,0 +1,34 @@
+use core::alloc::{GlobalAlloc, Layout};
+use libc;
+
+struct Alloc;
+
+// This is heavily adapted from the libc_alloc code at
+// https://github.com/daniel5151/libc_alloc/blob/aaf3c99494c1a938520c7d70668454e456e9a694/src/lib.rs#L31-L68
+unsafe impl GlobalAlloc for Alloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        libc::memalign(
+            layout.align().max(core::mem::size_of::<usize>()),
+            layout.size(),
+        ) as *mut _
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        libc::free(ptr as *mut _);
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
+        libc::realloc(ptr as *mut _, new_size) as *mut u8
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Alloc = Alloc;
+
+#[alloc_error_handler]
+fn handle(layout: core::alloc::Layout) -> ! {
+    panic!("memory allocation failed: {:#?}", layout);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
+#![feature(alloc_error_handler)]
 
 use core::panic::PanicInfo;
 use libc_print::libc_println;
 
+mod alloc;
 mod bindings;
 mod motor;
 mod peripherals;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 use core::panic::PanicInfo;
-use libc_alloc::LibcAlloc;
 use libc_print::libc_println;
 
 mod bindings;
@@ -27,6 +26,3 @@ fn panic(panic_info: &PanicInfo) -> ! {
 
     loop {}
 }
-
-#[global_allocator]
-static ALLOCATOR: LibcAlloc = LibcAlloc;


### PR DESCRIPTION
The allocation provided by `libc_alloc` uses `posix_memalign`, which is POSIX-only, rather than `memalign`, which is provided by `newlib`.